### PR TITLE
remove eval

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -17,7 +17,7 @@ end
 for __u in (°ᵃ, arcminuteᵃ, arcsecondᵃ, asᵃ, doubleTurnᵃ, turnᵃ, halfTurnᵃ, quadrantᵃ,
             sextantᵃ, octantᵃ, clockPositionᵃ, hourAngleᵃ, compassPointᵃ, hexacontadeᵃ,
             bradᵃ, gradᵃ, ʰᵃ, ᵐᵃ, ˢᵃ)
-    @eval __A = Quantity{T, 𝐀, typeof($__u)} where {T}
+    __A = Quantity{T, 𝐀, typeof(__u)} where {T}
     Base.sin(x::__A) = sinpi(__normalize_pi(x))
     Base.cos(x::__A) = cospi(__normalize_pi(x))
     Base.cis(x::__A) = cispi(__normalize_pi(x))


### PR DESCRIPTION
Eval has a global scope, so __A is overwritten a few times. This gives me a warning on the next function that suggests it should have local __A since global __A already exists.

I think its fine to not eval here, i tried `sin(30u"°ᵃ")` and that seemed to work fine